### PR TITLE
Change mypy -> pylama in pylama section

### DIFF
--- a/pages/docs/linting/index.md
+++ b/pages/docs/linting/index.md
@@ -169,8 +169,8 @@ Custom command line arguments can be passed into mypy just as with the other lin
 ### <a id="pylama"></a>pylama
 As mentioned previously, usage of this linter is turned off by the extension.    
 
-**Installing mypy**
-For this to work properly ensure mypy is installed locally.    
+**Installing pylama**
+For this to work properly ensure  pylama is installed locally.    
 You can easily install pylama as follows:    
 ```pip install pylama```
 


### PR DESCRIPTION
In linting page under pylama section, there's mention of mypy instead of pylama